### PR TITLE
nvapi: Add support for Reflex

### DIFF
--- a/src/d3d/nvapi_d3d_instance.cpp
+++ b/src/d3d/nvapi_d3d_instance.cpp
@@ -1,4 +1,5 @@
 #include "../util/util_log.h"
+#include "nvapi_d3d_low_latency_device.h"
 #include "nvapi_d3d_instance.h"
 
 namespace dxvk {
@@ -13,25 +14,40 @@ namespace dxvk {
             log::write("LatencyFleX loaded and initialized successfully");
     }
 
-    bool NvapiD3dInstance::IsReflexAvailable() {
+    bool NvapiD3dInstance::IsReflexAvailable(IUnknown* device) {
+        return NvapiD3dLowLatencyDevice::SupportsLowLatency(device) || m_lfx->IsAvailable();
+    }
+
+    bool NvapiD3dInstance::IsLowLatencyEnabled() const {
+        return m_isLowLatencyEnabled;
+    }
+
+    bool NvapiD3dInstance::IsUsingLfx() const {
         return m_lfx->IsAvailable();
     }
 
-    bool NvapiD3dInstance::IsReflexEnabled() const {
-        return m_isLfxEnabled;
+    bool NvapiD3dInstance::SetReflexMode(IUnknown* device, bool enable, bool boost, uint32_t frameTimeUs) {
+        bool result = true;
+
+        if (IsReflexAvailable(device))
+            m_isLowLatencyEnabled = enable;
+
+        if (m_lfx->IsAvailable() && enable)
+            m_lfx->SetTargetFrameTime(frameTimeUs * kNanoInMicro);
+        else if (NvapiD3dLowLatencyDevice::SupportsLowLatency(device))
+            result = NvapiD3dLowLatencyDevice::SetLatencySleepMode(device, enable, boost, frameTimeUs);
+
+        return result;
     }
 
-    void NvapiD3dInstance::SetReflexEnabled(bool value) {
-        m_isLfxEnabled = value;
-    }
+    bool NvapiD3dInstance::Sleep(IUnknown* device) {
+        bool result = true;
 
-    void NvapiD3dInstance::Sleep() {
-        if (m_isLfxEnabled)
+        if (m_lfx->IsAvailable() && m_isLowLatencyEnabled)
             m_lfx->WaitAndBeginFrame();
-    }
+        else if (NvapiD3dLowLatencyDevice::SupportsLowLatency(device))
+            result = NvapiD3dLowLatencyDevice::LatencySleep(device);
 
-    void NvapiD3dInstance::SetTargetFrameTime(uint64_t frameTimeUs) {
-        constexpr uint64_t kNanoInMicro = 1000;
-        m_lfx->SetTargetFrameTime(frameTimeUs * kNanoInMicro);
+        return result;
     }
 }

--- a/src/d3d/nvapi_d3d_instance.h
+++ b/src/d3d/nvapi_d3d_instance.h
@@ -10,15 +10,17 @@ namespace dxvk {
         ~NvapiD3dInstance();
 
         void Initialize();
-        [[nodiscard]] bool IsReflexAvailable();
-        [[nodiscard]] bool IsReflexEnabled() const;
-        void SetReflexEnabled(bool value);
-        void Sleep();
-        void SetTargetFrameTime(uint64_t frameTimeUs);
+        [[nodiscard]] bool IsReflexAvailable(IUnknown* device);
+        [[nodiscard]] bool IsLowLatencyEnabled() const;
+        [[nodiscard]] bool IsUsingLfx() const;
+        [[nodiscard]] bool SetReflexMode(IUnknown* device, bool enable, bool boost, uint32_t frameTimeUs);
+        [[nodiscard]] bool Sleep(IUnknown* device);
 
       private:
+        constexpr static uint64_t kNanoInMicro = 1000;
+
         ResourceFactory& m_resourceFactory;
         std::unique_ptr<Lfx> m_lfx;
-        bool m_isLfxEnabled = false;
+        bool m_isLowLatencyEnabled = false;
     };
 }

--- a/src/d3d/nvapi_d3d_low_latency_device.cpp
+++ b/src/d3d/nvapi_d3d_low_latency_device.cpp
@@ -1,0 +1,58 @@
+#include "nvapi_d3d_low_latency_device.h"
+
+namespace dxvk {
+    bool NvapiD3dLowLatencyDevice::SupportsLowLatency(IUnknown* device) {
+        auto d3dLowLatencyDevice = GetLowLatencyDevice(device);
+        if (d3dLowLatencyDevice == nullptr)
+            return false;
+
+        return d3dLowLatencyDevice->SupportsLowLatency();
+    }
+
+    bool NvapiD3dLowLatencyDevice::LatencySleep(IUnknown* device) {
+        auto d3dLowLatencyDevice = GetLowLatencyDevice(device);
+        if (d3dLowLatencyDevice == nullptr)
+            return false;
+
+        return SUCCEEDED(d3dLowLatencyDevice->LatencySleep());
+    }
+
+    bool NvapiD3dLowLatencyDevice::SetLatencySleepMode(IUnknown* device, bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs) {
+        auto d3dLowLatencyDevice = GetLowLatencyDevice(device);
+        if (d3dLowLatencyDevice == nullptr)
+            return false;
+
+        return SUCCEEDED(d3dLowLatencyDevice->SetLatencySleepMode(lowLatencyMode, lowLatencyBoost, minimumIntervalUs));
+    }
+
+    bool NvapiD3dLowLatencyDevice::GetLatencyInfo(IUnknown* device, D3D_LATENCY_RESULTS* latencyResults) {
+        auto d3dLowLatencyDevice = GetLowLatencyDevice(device);
+        if (d3dLowLatencyDevice == nullptr)
+            return false;
+
+        return SUCCEEDED(d3dLowLatencyDevice->GetLatencyInfo(latencyResults));
+    }
+
+    bool NvapiD3dLowLatencyDevice::SetLatencyMarker(IUnknown* device, uint64_t frameID, uint32_t markerType) {
+        auto d3dLowLatencyDevice = GetLowLatencyDevice(device);
+        if (d3dLowLatencyDevice == nullptr)
+            return false;
+
+        return SUCCEEDED(d3dLowLatencyDevice->SetLatencyMarker(frameID, markerType));
+    }
+
+    Com<ID3DLowLatencyDevice> NvapiD3dLowLatencyDevice::GetLowLatencyDevice(IUnknown* device) {
+        std::scoped_lock lock(m_LowLatencyDeviceMutex);
+        auto it = m_lowLatencyDeviceMap.find(device);
+        if (it != m_lowLatencyDeviceMap.end())
+            return it->second;
+
+        Com<ID3DLowLatencyDevice> d3dLowLatencyDevice;
+        if (FAILED(device->QueryInterface(IID_PPV_ARGS(&d3dLowLatencyDevice))))
+            return nullptr;
+
+        m_lowLatencyDeviceMap.emplace(device, d3dLowLatencyDevice.ptr());
+
+        return d3dLowLatencyDevice;
+    }
+}

--- a/src/d3d/nvapi_d3d_low_latency_device.h
+++ b/src/d3d/nvapi_d3d_low_latency_device.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "../nvapi_private.h"
+#include "../shared/shared_interfaces.h"
+#include "../util/com_pointer.h"
+
+namespace dxvk {
+    class NvapiD3dLowLatencyDevice {
+      public:
+        static bool SupportsLowLatency(IUnknown* device);
+        static bool LatencySleep(IUnknown* device);
+        static bool SetLatencySleepMode(IUnknown* device, bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs);
+        static bool GetLatencyInfo(IUnknown* device, D3D_LATENCY_RESULTS* latencyResults);
+        static bool SetLatencyMarker(IUnknown* device, uint64_t frameID, uint32_t markerType);
+
+      private:
+        inline static std::unordered_map<IUnknown*, ID3DLowLatencyDevice*> m_lowLatencyDeviceMap;
+
+        inline static std::mutex m_LowLatencyDeviceMutex;
+
+        [[nodiscard]] static Com<ID3DLowLatencyDevice> GetLowLatencyDevice(IUnknown* device);
+    };
+}

--- a/src/d3d12/nvapi_d3d12_device.h
+++ b/src/d3d12/nvapi_d3d12_device.h
@@ -24,6 +24,7 @@ namespace dxvk {
         static bool DestroyCubinComputeShader(ID3D12Device* device, NVDX_ObjectHandle shader);
         static bool GetCudaTextureObject(ID3D12Device* device, D3D12_CPU_DESCRIPTOR_HANDLE srvHandle, D3D12_CPU_DESCRIPTOR_HANDLE samplerHandle, NvU32* cudaTextureHandle);
         static bool GetCudaSurfaceObject(ID3D12Device* device, D3D12_CPU_DESCRIPTOR_HANDLE uavHandle, NvU32* cudaSurfaceHandle);
+        static bool NotifyOutOfBandCommandQueue(ID3D12CommandQueue* commandQueue, D3D12_OUT_OF_BAND_CQ_TYPE type);
         static bool LaunchCubinShader(ID3D12GraphicsCommandList* commandList, NVDX_ObjectHandle shader, NvU32 blockX, NvU32 blockY, NvU32 blockZ, const void* params, NvU32 paramSize);
         static bool CaptureUAVInfo(ID3D12Device* device, NVAPI_UAV_INFO* uavInfo);
         static bool IsFatbinPTXSupported(ID3D12Device* device);
@@ -32,15 +33,18 @@ namespace dxvk {
 
       private:
         inline static std::unordered_map<ID3D12Device*, ID3D12DeviceExt*> m_cubinDeviceMap;
+        inline static std::unordered_map<ID3D12CommandQueue*, ID3D12CommandQueueExt*> m_commandQueueMap;
         inline static std::unordered_map<ID3D12GraphicsCommandList*, CommandListExtWithVersion> m_commandListMap;
         inline static std::unordered_map<NVDX_ObjectHandle, NvU32> m_cubinSmemMap;
 
         inline static std::mutex m_commandListMutex;
+        inline static std::mutex m_commandQueueMutex;
         inline static std::mutex m_cubinDeviceMutex;
         inline static std::mutex m_cubinSmemMutex;
 
         [[nodiscard]] static Com<ID3D12DeviceExt> GetCubinDevice(ID3D12Device* device);
         [[nodiscard]] static Com<ID3D12DeviceExt> GetDeviceExt(ID3D12Device* device, D3D12_VK_EXTENSION extension);
+        [[nodiscard]] static Com<ID3D12CommandQueueExt> GetCommandQueueExt(ID3D12CommandQueue* commandQueue);
         [[nodiscard]] static std::optional<CommandListExtWithVersion> GetCommandListExt(ID3D12GraphicsCommandList* commandList);
     };
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -10,6 +10,7 @@ nvapi_src = files([
   'resource_factory.cpp',
   'd3d/lfx.cpp',
   'd3d/nvapi_d3d_instance.cpp',
+  'd3d/nvapi_d3d_low_latency_device.cpp',
   'd3d11/nvapi_d3d11_device.cpp',
   'd3d12/nvapi_d3d12_device.cpp',
   'nvapi_globals.cpp',

--- a/src/nvapi_interface.cpp
+++ b/src/nvapi_interface.cpp
@@ -69,6 +69,8 @@ extern "C" {
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_GetRaytracingCaps)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx)
+        INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_NotifyOutOfBandCommandQueue)
+        INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_SetAsyncFrameMarker)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D_GetObjectHandleForResource)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D_SetResourceHint)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D_GetCurrentSLIState)

--- a/src/shared/shared_interfaces.h
+++ b/src/shared/shared_interfaces.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "../nvapi_private.h"
+
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+#endif // __GNUC__
+
+/**
+ * \brief Frame Report Info
+ */
+typedef struct D3D_LATENCY_RESULTS {
+    UINT32 version;
+    struct D3D_FRAME_REPORT {
+        UINT64 frameID;
+        UINT64 inputSampleTime;
+        UINT64 simStartTime;
+        UINT64 simEndTime;
+        UINT64 renderSubmitStartTime;
+        UINT64 renderSubmitEndTime;
+        UINT64 presentStartTime;
+        UINT64 presentEndTime;
+        UINT64 driverStartTime;
+        UINT64 driverEndTime;
+        UINT64 osRenderQueueStartTime;
+        UINT64 osRenderQueueEndTime;
+        UINT64 gpuRenderStartTime;
+        UINT64 gpuRenderEndTime;
+        UINT32 gpuActiveRenderTimeUs;
+        UINT32 gpuFrameTimeUs;
+        UINT8 rsvd[120];
+    } frame_reports[64];
+    UINT8 rsvd[32];
+} D3D_LATENCY_RESULTS;
+
+MIDL_INTERFACE("f3112584-41f9-348d-a59b-00b7e1d285d6")
+ID3DLowLatencyDevice : public IUnknown {
+    virtual BOOL STDMETHODCALLTYPE SupportsLowLatency() = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE LatencySleep() = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE SetLatencySleepMode(
+        BOOL lowLatencyMode,
+        BOOL lowLatencyBoost,
+        uint32_t minimumIntervalUs) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE SetLatencyMarker(
+        uint64_t frameID,
+        uint32_t markerType) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE GetLatencyInfo(
+        D3D_LATENCY_RESULTS * latencyResults) = 0;
+};
+
+#ifndef _MSC_VER
+__CRT_UUID_DECL(ID3DLowLatencyDevice, 0xf3112584, 0x41f9, 0x348d, 0xa5, 0x9b, 0x00, 0xb7, 0xe1, 0xd2, 0x85, 0xd6);
+#endif

--- a/src/vkd3d-proton/vkd3d-proton_interfaces.h
+++ b/src/vkd3d-proton/vkd3d-proton_interfaces.h
@@ -25,7 +25,13 @@
 
 enum D3D12_VK_EXTENSION : uint32_t {
     D3D12_VK_NVX_BINARY_IMPORT = 0x1,
-    D3D12_VK_NVX_IMAGE_VIEW_HANDLE = 0x2
+    D3D12_VK_NVX_IMAGE_VIEW_HANDLE = 0x2,
+    D3D12_VK_NV_LOW_LATENCY_2 = 0x3
+};
+
+enum D3D12_OUT_OF_BAND_CQ_TYPE : uint32_t {
+    D3D_OUT_OF_BAND_RENDER = 0x0,
+    D3D_OUT_OF_BAND_PRESENT = 0x1
 };
 
 struct D3D12_CUBIN_DATA_HANDLE {
@@ -106,8 +112,15 @@ ID3D12GraphicsCommandListExt1 : public ID3D12GraphicsCommandListExt {
         UINT32 raw_params_count) = 0;
 };
 
+MIDL_INTERFACE("40ed3f96-e773-e9bc-fc0c-e95560c99ad6")
+ID3D12CommandQueueExt : public IUnknown {
+    virtual HRESULT STDMETHODCALLTYPE NotifyOutOfBandCommandQueue(
+        D3D12_OUT_OF_BAND_CQ_TYPE type) = 0;
+};
+
 #ifndef _MSC_VER
 __CRT_UUID_DECL(ID3D12DeviceExt, 0x11ea7a1a, 0x0f6a, 0x49bf, 0xb6, 0x12, 0x3e, 0x30, 0xf8, 0xe2, 0x01, 0xdd);
 __CRT_UUID_DECL(ID3D12GraphicsCommandListExt, 0x77a86b09, 0x2bea, 0x4801, 0xb8, 0x9a, 0x37, 0x64, 0x8e, 0x10, 0x4a, 0xf1);
 __CRT_UUID_DECL(ID3D12GraphicsCommandListExt1, 0xd53b0028, 0xafb4, 0x4b65, 0xa4, 0xf1, 0x7b, 0x0d, 0xaa, 0xa6, 0x5b, 0x4f);
+__CRT_UUID_DECL(ID3D12CommandQueueExt, 0x40ed3f96, 0xe773, 0xe9bc, 0xfc, 0x0c, 0xe9, 0x55, 0x60, 0xc9, 0x9a, 0xd6);
 #endif

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,6 +6,7 @@ nvapi_src = files([
   '../src/sysinfo/nvml.cpp',
   '../src/d3d/lfx.cpp',
   '../src/d3d/nvapi_d3d_instance.cpp',
+  '../src/d3d/nvapi_d3d_low_latency_device.cpp',
   '../src/sysinfo/nvapi_output.cpp',
   '../src/sysinfo/nvapi_adapter.cpp',
   '../src/sysinfo/nvapi_adapter_registry.cpp',

--- a/tests/nvapi_d3d12_mocks.h
+++ b/tests/nvapi_d3d12_mocks.h
@@ -177,3 +177,32 @@ class D3D12Vkd3dGraphicsCommandListMock final : public trompeloeil::mock_interfa
     IMPLEMENT_MOCK6(LaunchCubinShader);
     IMPLEMENT_MOCK9(LaunchCubinShaderEx);
 };
+
+class ID3D12Vkd3dCommandQueue : public ID3D12CommandQueue, public ID3D12CommandQueueExt {};
+
+class D3D12Vkd3dCommandQueueMock final : public trompeloeil::mock_interface<ID3D12Vkd3dCommandQueue> {
+    MAKE_MOCK2(QueryInterface, HRESULT(REFIID, void**), override);
+    MAKE_MOCK0(AddRef, ULONG(), override);
+    MAKE_MOCK0(Release, ULONG(), override);
+    IMPLEMENT_MOCK3(GetPrivateData);
+    IMPLEMENT_MOCK3(SetPrivateData);
+    IMPLEMENT_MOCK2(SetPrivateDataInterface);
+    IMPLEMENT_MOCK1(SetName);
+    IMPLEMENT_MOCK2(GetDevice);
+    IMPLEMENT_MOCK10(UpdateTileMappings);
+    IMPLEMENT_MOCK6(CopyTileMappings);
+    IMPLEMENT_MOCK2(ExecuteCommandLists);
+    IMPLEMENT_MOCK3(SetMarker);
+    IMPLEMENT_MOCK3(BeginEvent);
+    IMPLEMENT_MOCK0(EndEvent);
+    IMPLEMENT_MOCK2(Signal);
+    IMPLEMENT_MOCK2(Wait);
+    IMPLEMENT_MOCK1(GetTimestampFrequency);
+    IMPLEMENT_MOCK2(GetClockCalibration);
+#if defined(WIDL_EXPLICIT_AGGREGATE_RETURNS)
+    MAKE_MOCK1(GetDesc, D3D12_COMMAND_QUEUE_DESC*(D3D12_COMMAND_QUEUE_DESC*), override);
+#else
+    IMPLEMENT_MOCK0(GetDesc);
+#endif
+    IMPLEMENT_MOCK1(NotifyOutOfBandCommandQueue);
+};

--- a/tests/nvapi_d3d_mocks.h
+++ b/tests/nvapi_d3d_mocks.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "nvapi_tests_private.h"
+#include "../src/shared/shared_interfaces.h"
 #include "../src/d3d/lfx.h"
 
 class UnknownMock : public trompeloeil::mock_interface<IUnknown> {
@@ -13,4 +14,15 @@ class LfxMock : public trompeloeil::mock_interface<dxvk::Lfx> {
     IMPLEMENT_CONST_MOCK0(IsAvailable);
     IMPLEMENT_MOCK0(WaitAndBeginFrame);
     IMPLEMENT_MOCK1(SetTargetFrameTime);
+};
+
+class D3DLowLatencyDeviceMock : public trompeloeil::mock_interface<ID3DLowLatencyDevice> {
+    MAKE_MOCK2(QueryInterface, HRESULT(REFIID, void**), override);
+    MAKE_MOCK0(AddRef, ULONG(), override);
+    MAKE_MOCK0(Release, ULONG(), override);
+    IMPLEMENT_MOCK0(SupportsLowLatency);
+    IMPLEMENT_MOCK0(LatencySleep);
+    IMPLEMENT_MOCK3(SetLatencySleepMode);
+    IMPLEMENT_MOCK2(SetLatencyMarker);
+    IMPLEMENT_MOCK1(GetLatencyInfo);
 };

--- a/tests/nvapi_tests_private.h
+++ b/tests/nvapi_tests_private.h
@@ -4,6 +4,7 @@
 
 #include "../src/nvapi_private.h"
 #include "../src/nvapi_globals.h"
+#include "../src/d3d/nvapi_d3d_low_latency_device.h"
 #include "../src/d3d11/nvapi_d3d11_device.h"
 #include "../src/d3d12/nvapi_d3d12_device.h"
 #include "../inc/catch_amalgamated.hpp"


### PR DESCRIPTION
The intent of this commit is to enable Reflex for all D3D11, and D3D12 titles using dxvk-nvapi. It does this through a new device interface called ID3DLowLatencyDevice. This interface will be implemented by ID3D12Device in vkd3d-proton, and ID3D11Device in dxvk.

To provide compatibility with LatencyFleX this change will only use the ID3DLowLatencyDevice interface when LatencyFleX is not detected.